### PR TITLE
Remove export on rpc procs

### DIFF
--- a/eth-rpc/server/servertypes.nim
+++ b/eth-rpc/server/servertypes.nim
@@ -71,18 +71,18 @@ macro rpc*(server: var RpcServer, path: string, body: untyped): untyped =
     if returnType == ident"JsonNode":
       # `JsonNode` results don't need conversion
       result.add( quote do:
-        proc `procName`*(`paramsIdent`: JsonNode): Future[JsonNode] {.async.} =
+        proc `procName`(`paramsIdent`: JsonNode): Future[JsonNode] {.async.} =
           `res` = await `doMain`(`paramsIdent`)
       )
     else:
       result.add(quote do:
-        proc `procName`*(`paramsIdent`: JsonNode): Future[JsonNode] {.async.} =
+        proc `procName`(`paramsIdent`: JsonNode): Future[JsonNode] {.async.} =
           `res` = %await `doMain`(`paramsIdent`)
       )
   else:
     # no return types, inline contents
     result.add(quote do:
-      proc `procName`*(`paramsIdent`: JsonNode): Future[JsonNode] {.async.} =
+      proc `procName`(`paramsIdent`: JsonNode): Future[JsonNode] {.async.} =
         `setup`
         `procBody`
     )

--- a/eth-rpc/server/servertypes.nim
+++ b/eth-rpc/server/servertypes.nim
@@ -44,7 +44,7 @@ proc hasReturnType(params: NimNode): bool =
   if params != nil and params.len > 0 and params[0] != nil and params[0].kind != nnkEmpty:
     result = true
 
-macro rpc*(server: var RpcServer, path: string, body: untyped): untyped =
+macro rpc*(server: RpcServer, path: string, body: untyped): untyped =
   result = newStmtList()
   let
     parameters = body.findChild(it.kind == nnkFormalParams)

--- a/tests/testserverclient.nim
+++ b/tests/testserverclient.nim
@@ -5,7 +5,7 @@ var srv = newRpcServer()
 srv.address = "localhost"
 srv.port = Port(8545)
 
-proc makeProc(server: var RpcServer) =
+proc makeProc(server: RpcServer) =
   server.rpc("myProc") do(input: string, data: array[0..3, int]):
     result = %("Hello " & input & " data: " & $data)
 

--- a/tests/testserverclient.nim
+++ b/tests/testserverclient.nim
@@ -5,10 +5,13 @@ var srv = newRpcServer()
 srv.address = "localhost"
 srv.port = Port(8545)
 
-srv.rpc("myProc") do(input: string, data: array[0..3, int]):
-  result = %("Hello " & input & " data: " & $data)
+proc makeProc(server: var RpcServer) =
+  server.rpc("myProc") do(input: string, data: array[0..3, int]):
+    result = %("Hello " & input & " data: " & $data)
 
 asyncCheck srv.serve
+
+srv.makeProc
 
 suite "Server/Client RPC":
   proc main {.async.} =


### PR DESCRIPTION
Allows `rpc` to be invoked in a procedure scope:

```nim
proc makeProc(server: var RpcServer) =
  server.rpc("myProc") do:
    # ...
```